### PR TITLE
Debug fmt test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5479,6 +5479,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -17,6 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 frame-support = { default-features = false, version = "3.0.0", path = "../../../../frame/support" }
 frame-system = { default-features = false,  version = "3.0.0",  path = "../../../../frame/system" }
 frame-benchmarking = { default-features = false,  version = "3.1.0",  path = "../../../../frame/benchmarking", optional = true }
+sp-std = { default-features = false, version = "3.0.0",  path = "../../../../primitives/std" }
 
 [dev-dependencies]
 serde = { version = "1.0.119" }
@@ -31,6 +32,7 @@ std = [
 	'frame-support/std',
 	'frame-system/std',
 	'frame-benchmarking/std',
+	'sp-std/std',
 ]
 
 runtime-benchmarks = ["frame-benchmarking"]

--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -19,6 +19,38 @@ mod benchmarking;
 pub mod pallet {
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
+	use codec::{Encode, Decode};
+	use sp_std::prelude::Vec;
+
+	#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+	pub struct Arg {}
+
+	/*
+	
+	== If Debug trait is not implemented we get compiler error == 
+
+	error[E0277]: `Arg` doesn't implement `std::fmt::Debug`
+   --> bin/node-template/pallets/template/src/lib.rs:121:46
+    |
+121 |         pub fn breakit(origin: OriginFor<T>, _arg: Vec<Arg>) -> DispatchResult {
+    |                                                    ^^^^^^^^ `Arg` cannot be formatted using `{:?}`
+    |
+    = help: the trait `std::fmt::Debug` is not implemented for `Arg`
+    = note: add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
+    = note: required because of the requirements on the impl of `std::fmt::Debug` for `Vec<Arg>`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&Vec<Arg>`
+    = note: required for the cast to the object type `dyn std::fmt::Debug`
+
+	We Implement Debug trait because we are required to. We could derive the trait, but
+	we are explicitly implementing it and making it panic to figure out when it is invoked.
+	*/
+	impl sp_std::fmt::Debug for Arg {
+		fn fmt(&self, _formatter: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+			panic!("Arg::fmt()");
+			Ok(())
+		}
+	}
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
@@ -102,6 +134,13 @@ pub mod pallet {
 					Ok(())
 				},
 			}
+		}
+
+		/// Break it
+		#[pallet::weight(10_000)]
+		pub fn breakit(origin: OriginFor<T>, _arg: Vec<Arg>) -> DispatchResult {
+			let _who = ensure_signed(origin)?;
+			Ok(())
 		}
 	}
 }


### PR DESCRIPTION
This PR is just to demonstrate and test an issue which seems strange.

For a type that is an argument for a dispatchable it is required that it implements the `Debug` trait. The `fmt()` method appears to get invoked only in native execution of the runtime and when global log level is info, debug or trace, but only when a client is syncing and importing blocks.

To get a stack trace I implemented the trait to panic, to confirm the above.

The stack trace will look like this:

```
Version: 3.0.0-5bae08659-x86_64-macos

   0: backtrace::backtrace::trace
   1: backtrace::capture::Backtrace::new
   2: sp_panic_handler::set::{{closure}}
   3: std::panicking::rust_panic_with_hook
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/std/src/panicking.rs:595:17
   4: std::panicking::begin_panic::{{closure}}
   5: std::sys_common::backtrace::__rust_end_short_backtrace
   6: std::panicking::begin_panic
   7: <pallet_template::pallet::Arg as core::fmt::Debug>::fmt
   8: core::fmt::builders::DebugInner::entry::{{closure}}
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:417:17
      core::result::Result<T,E>::and_then
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/result.rs:704:22
      core::fmt::builders::DebugInner::entry
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:403:23
   9: core::fmt::builders::DebugSet::entry
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:492:9
  10: <&T as core::fmt::Debug>::fmt
  11: core::fmt::builders::DebugTuple::field::{{closure}}
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:345:17
      core::result::Result<T,E>::and_then
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/result.rs:704:22
      core::fmt::builders::DebugTuple::field
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:332:23
  12: pallet_template::pallet::_::<impl core::fmt::Debug for pallet_template::pallet::Call<T>>::fmt
  13: core::fmt::builders::DebugTuple::field::{{closure}}
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:345:17
      core::result::Result<T,E>::and_then
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/result.rs:704:22
      core::fmt::builders::DebugTuple::field
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:332:23
  14: <node_template_runtime::Call as core::fmt::Debug>::fmt
  15: core::fmt::write
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/mod.rs:1092:17
  16: core::fmt::Formatter::write_fmt
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/mod.rs:1535:9
  17: <&T as core::fmt::Debug>::fmt
  18: core::fmt::builders::DebugInner::entry::{{closure}}
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:417:17
      core::result::Result<T,E>::and_then
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/result.rs:704:22
      core::fmt::builders::DebugInner::entry
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:403:23
  19: core::fmt::builders::DebugSet::entry
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:492:9
  20: <alloc::vec::Vec<T,A> as core::fmt::Debug>::fmt
  21: core::fmt::builders::DebugStruct::field::{{closure}}
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:154:17
      core::result::Result<T,E>::and_then
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/result.rs:704:22
      core::fmt::builders::DebugStruct::field
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/builders.rs:137:23
  22: <&T as core::fmt::Debug>::fmt
  23: core::fmt::write
             at /rustc/07e0e2ec268c140e607e1ac7f49f145612d0f597/library/core/src/fmt/mod.rs:1092:17
  24: core::fmt::Write::write_fmt
  25: <tracing_subscriber::fmt::format::DefaultVisitor as tracing_core::field::Visit>::record_debug
  26: tracing_core::span::Attributes::record
  27: <tracing_subscriber::fmt::fmt_layer::Layer<S,N,E,W> as tracing_subscriber::layer::Layer<S>>::new_span
  28: <tracing_subscriber::fmt::Subscriber<N,E,F,W> as tracing_core::subscriber::Subscriber>::new_span
  29: <tracing_subscriber::layer::Layered<L,S> as tracing_core::subscriber::Subscriber>::new_span
  30: tracing::span::Span::make_with
  31: tracing_core::dispatcher::get_default
  32: tracing::span::Span::new
  33: frame_executive::Executive<System,Block,Context,UnsignedValidator,AllPallets,COnRuntimeUpgrade>::execute_block
  34: <node_template_runtime::Runtime as sp_api::runtime_decl_for_Core::Core<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u32,sp_runtime::traits::BlakeTwo256>,sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic<sp_runtime::multiaddress::MultiAddress<<<sp_runtime::MultiSignature as sp_runtime::traits::Verify>::Signer as sp_runtime::traits::IdentifyAccount>::AccountId,()>,node_template_runtime::Call,sp_runtime::MultiSignature,(frame_system::extensions::check_spec_version::CheckSpecVersion<node_template_runtime::Runtime>,frame_system::extensions::check_tx_version::CheckTxVersion<node_template_runtime::Runtime>,frame_system::extensions::check_genesis::CheckGenesis<node_template_runtime::Runtime>,frame_system::extensions::check_mortality::CheckMortality<node_template_runtime::Runtime>,frame_system::extensions::check_nonce::CheckNonce<node_template_runtime::Runtime>,frame_system::extensions::check_weight::CheckWeight<node_template_runtime::Runtime>,pallet_transaction_payment::ChargeTransactionPayment<node_template_runtime::Runtime>)>>>>::execute_block
  35: sp_api::runtime_decl_for_Core::execute_block_native_call_generator::{{closure}}
  36: std::thread::local::LocalKey<T>::with
  37: sc_executor::native_executor::WasmExecutor::with_instance::{{closure}}
  38: sc_executor::wasm_runtime::RuntimeCache::with_instance
  39: <sc_executor::native_executor::NativeExecutor<D> as sp_core::traits::CodeExecutor>::call
  40: sp_state_machine::execution::StateMachine<B,H,N,Exec>::execute_aux
  41: sp_state_machine::execution::StateMachine<B,H,N,Exec>::execute_using_consensus_failure_handler
  42: <sc_service::client::call_executor::LocalCallExecutor<B,E> as sc_client_api::call_executor::CallExecutor<Block>>::contextual_call
  43: <sc_service::client::client::Client<B,E,Block,RA> as sp_api::CallApiAt<Block>>::call_api_at
  44: sp_api::runtime_decl_for_Core::execute_block_call_api_at
  45: sp_api::Core::execute_block_with_context
  46: sc_service::client::client::Client<B,E,Block,RA>::prepare_block_storage_changes
  47: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
```


To reproduce, build the node-template from this branch and run a dev chain (alice as validator). Use polkadot-js to send an extrinsic dispatching `templateModule.breakIt()` 

start another node using first node as its bootnode.

To bypass the panic run the second node either with `--log warn`  or `--execution Wasm`

This behavior happens on substrate latest master, substrate v2.0.1

It does not happen on substrate v2.0.0-rc4

As far as I know the Debug trait is useful when writing tests for comparing values of a type in assertions, like `assert_eq` but never realized it was used elsewhere in the runtime.

Questions:
Where does the formatted string get logged/written?
Does it in anyway affect consensus, chain-state?
Is this a bug or by design?
